### PR TITLE
Fix cmake in PR symbolic trace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
         python2 \
         python3-pip \
         zlib1g-dev \
+        nlohmann-json3-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install lit
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Under Ubuntu Groovy the following one liner should install all required
 packages:
 
 ```
-sudo apt install -y git cargo clang-14 cmake g++ git libz3-dev llvm-14-dev llvm-14-tools ninja-build python2 python3-pip zlib1g-dev && sudo pip3 install lit
+sudo apt install -y git cargo clang-14 cmake g++ git libz3-dev llvm-14-dev llvm-14-tools ninja-build python2 python3-pip zlib1g-dev nlohmann-json3-dev && sudo pip3 install lit
 ```
 
 Alternatively, see below for using the provided Dockerfile, or the file

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -37,6 +37,8 @@ set(SHARED_RUNTIME_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/Tracer.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/GarbageCollection.cpp)
 
+find_package(nlohmann_json REQUIRED)
+
 if (${QSYM_BACKEND})
   add_subdirectory(qsym_backend)
 else()

--- a/runtime/qsym_backend/CMakeLists.txt
+++ b/runtime/qsym_backend/CMakeLists.txt
@@ -83,12 +83,6 @@ target_include_directories(SymRuntime SYSTEM PRIVATE
 # We need to get the LLVM support component for llvm::APInt.
 llvm_map_components_to_libnames(QSYM_LLVM_DEPS support)
 
-include(FetchContent)
-
-FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.2/json.tar.xz)
-FetchContent_MakeAvailable(json)
-
-
 target_link_libraries(SymRuntime ${Z3_LIBRARIES} ${QSYM_LLVM_DEPS} nlohmann_json::nlohmann_json)
 
 # We use std::filesystem, which has been added in C++17. Before its official


### PR DESCRIPTION
Hi,
As I promised here is a PR to fix importing nlohmann-json in cmake. Instead of fetching it on each cmake command it uses now an external (so a operating system) installation. Dockerfile and Readme has been updated respectively.